### PR TITLE
Ensure valid hostnames for SkyDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Note that the default `service-id` includes more than the container name (see be
 
 	docker run -d --name redis-1 -e SERVICE_ID=redis-1 -p 6379:6379 redis
 
+Registrator will remove invalid characters to ensure valid dns hostnames. So `myhostname:adoring_hopper:1337` will become `myhost-adoring-hopper-1337`.
+
 ## How it works
 
 Services are registered and deregistered based on container start and die events from Docker. The service definitions are created with information from the container, including user-defined metadata in the container environment.
@@ -89,7 +91,7 @@ For each published port of a container, a `Service` object is created and passed
 		Attrs map[string]string    // any remaining service metadata from environment
 	}
 
-Most of these (except `IP` and `Port`) can be overridden by container environment metadata variables prefixed with `SERVICE_` or `SERVICE_<internal-port>_`. You use a port in the key name to refer to a particular port's service. Metadata variables without a port in the name are used as the default for all services or can be used to conveniently refer to the single exposed service. 
+Most of these (except `IP` and `Port`) can be overridden by container environment metadata variables prefixed with `SERVICE_` or `SERVICE_<internal-port>_`. You use a port in the key name to refer to a particular port's service. Metadata variables without a port in the name are used as the default for all services or can be used to conveniently refer to the single exposed service.
 
 Additional supported metadata in the same format `SERVICE_<metadata>`.
 IGNORE: Any value for ignore tells registrator to ignore this entire container and all associated ports.
@@ -129,7 +131,7 @@ Results in `Service`:
 		"Attrs": {"region": "us2"}
 	}
 
-Keep in mind not all of the `Service` object may be used by the registry backend. For example, currently none of them support registering arbitrary attributes. This field is there for future use. 
+Keep in mind not all of the `Service` object may be used by the registry backend. For example, currently none of them support registering arbitrary attributes. This field is there for future use.
 
 ### Multiple services with defaults
 
@@ -211,7 +213,7 @@ This feature is only available when using the `check-http` script that comes wit
 	SERVICE_80_CHECK_HTTP=/health/endpoint/path
 	SERVICE_80_CHECK_INTERVAL=15s
 
-It works for an HTTP service on any port, not just 80. If its the only service, you can also use `SERVICE_CHECK_HTTP`. 
+It works for an HTTP service on any port, not just 80. If its the only service, you can also use `SERVICE_CHECK_HTTP`.
 
 #### Run a health check script in the service container
 

--- a/skydns2.go
+++ b/skydns2.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/url"
 	"strconv"
+	"regexp"
 	"strings"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -46,7 +47,13 @@ func (r *Skydns2Registry) Refresh(service *Service) error {
 }
 
 func (r *Skydns2Registry) servicePath(service *Service) string {
-	return r.path + "/" + service.Name + "/" + service.ID
+	return r.path + "/" + slugify(service.Name) + "/" + slugify(service.ID)
+}
+
+func slugify(slug string) string {
+	slug = strings.ToLower(slug)
+	slug = regexp.MustCompile("[^a-z0-9-]").ReplaceAllString(slug, "-")
+	return strings.Trim(slug, "-")
 }
 
 func domainPath(domain string) string {


### PR DESCRIPTION
Slugifies `service.Name` and `service.ID` so that we always have a
valid dns name for containers with default Id's and so on.